### PR TITLE
fix the deprecation of `Call` 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   },
   "homepage": "https://github.com/justadudewhohacks/native-node-utils#readme",
   "dependencies": {
-    "nan": "^2.8.0"
+    "nan": "^2.11.0"
   }
 }

--- a/src/AsyncWorker.h
+++ b/src/AsyncWorker.h
@@ -26,13 +26,15 @@ namespace FF {
 		void HandleOKCallback() {
 			Nan::HandleScope scope;
 			v8::Local<v8::Value> argv[] = { Nan::Null(), worker->getReturnValue() };
-			callback->Call(2, argv);
+			Nan::AsyncResource resource("native-node-utils:AsyncWorker::HandleOKCallback");
+			resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), **callback, 2, argv);
 		}
 
 		void HandleErrorCallback() {
 			Nan::HandleScope scope;
 			v8::Local<v8::Value> argv[] = { Nan::New(this->ErrorMessage()).ToLocalChecked(), Nan::Null() };
-			callback->Call(2, argv);
+			Nan::AsyncResource resource("native-node-utils:AsyncWorker::HandleErrorCallback");
+			resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), **callback, 2, argv);
 		}
 	};
 

--- a/src/NativeNodeUtils.h
+++ b/src/NativeNodeUtils.h
@@ -79,7 +79,8 @@ namespace FF {
 			if (worker->applyUnwrappers(info)) {
 				v8::Local<v8::Value> argv[] = { Nan::Error(tryCatch.formatCatchedError(methodName)), Nan::Null() };
 				tryCatch.Reset();
-				callback->Call(2, argv);
+				Nan::AsyncResource resource("native-node-utils:AsyncBinding::run");
+				resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), **callback, 2, argv);
 				return;
 			}
 			Nan::AsyncQueueWorker(new FF::AsyncWorker(callback, worker));


### PR DESCRIPTION
I have test it locally by building opencv4nodejs with `npm link native-node-utils` and it works correctly.